### PR TITLE
helicopters now use player loadout frequencies

### DIFF
--- a/Generator/RotorOpsMission.py
+++ b/Generator/RotorOpsMission.py
@@ -642,6 +642,7 @@ class RotorOpsMission:
             default_loadouts[helicopter_group.units[0].unit_type.id]["pylons"] = helicopter_group.units[0].pylons
             default_loadouts[helicopter_group.units[0].unit_type.id]["livery_id"] = helicopter_group.units[0].livery_id
             default_loadouts[helicopter_group.units[0].unit_type.id]["fuel"] = helicopter_group.units[0].fuel
+            default_loadouts[helicopter_group.units[0].unit_type.id]["frequency"] = helicopter_group.frequency
 
         # find friendly carriers and farps
         carrier = self.m.country(jtf_blue).find_ship_group(name="HELO_CARRIER")
@@ -746,6 +747,7 @@ class RotorOpsMission:
                     fg.units[0].pylons = default_loadouts[helotype.id]["pylons"]
                     fg.units[0].livery_id = default_loadouts[helotype.id]["livery_id"]
                     fg.units[0].fuel = default_loadouts[helotype.id]["fuel"]
+                    fg.frequency = default_loadouts[helotype.id]["frequency"]
 
                 # setup wingman for single player
                 if len(fg.units) == 2:

--- a/Generator/version.py
+++ b/Generator/version.py
@@ -1,7 +1,7 @@
 # ROTOROPS VERSION
 maj_version = 1
 minor_version = 7
-patch_version = 1
+patch_version = 2
 
 version_url = 'https://dcs-helicopters.com/app-updates/versioncheck.yaml'
 


### PR DESCRIPTION
pydcs assigns invalid frequencies to UH-1H.  We now pull the frequency from the blue_player_loadouts.miz which could be a useful feature as well as fixing this bug. 